### PR TITLE
Fix the last tab indentation

### DIFF
--- a/main.js
+++ b/main.js
@@ -10,7 +10,6 @@ const { Hotkey, } = require('sdk/hotkeys');
 const baseUrl = require('sdk/self').data.url('../');
 
 const gSessionStore = Cc["@mozilla.org/browser/sessionstore;1"].getService(Ci.nsISessionStore);
-const SessionStoreNS = Cu.import('resource:///modules/sessionstore/SessionStore.jsm', {});
 Cu.importGlobalProperties([ 'btoa', ]); /* global btoa */
 const toBase64 = btoa;
 
@@ -138,7 +137,7 @@ function unloadTab(gBrowser, tab) {
 
 	// Close the original tab and remove it from the recently closed tabs list
 	gBrowser.removeTab(tab);
-	SessionStoreNS.SessionStoreInternal.forgetClosedTab(gBrowser.ownerGlobal);
+	gSessionStore.forgetClosedTab(gBrowser.ownerGlobal, 0);
 
 /// end copy
 }

--- a/main.js
+++ b/main.js
@@ -136,8 +136,12 @@ function unloadTab(gBrowser, tab) {
 /// copied from bartablitex@szabolcs.hubai
 
 	// Close the original tab and remove it from the recently closed tabs list
+	let gWindow = gBrowser.ownerGlobal;
+	let lastClosedTabCount = gSessionStore.getClosedTabCount(gWindow);
 	gBrowser.removeTab(tab);
-	gSessionStore.forgetClosedTab(gBrowser.ownerGlobal, 0);
+	if (gSessionStore.getClosedTabCount(gWindow) === lastClosedTabCount + 1) {
+		gSessionStore.forgetClosedTab(gBrowser.ownerGlobal, 0);
+	}
 
 /// end copy
 }

--- a/main.js
+++ b/main.js
@@ -237,7 +237,7 @@ function windowOpened(window) {
 		const itemTree = menu === singleMenu && gBrowser.treeStyleTab && addItem(
 			'context_unloadSubtree',
 			itemOthers.nextSibling,
-			'Unload Subtree',
+			'Unload this Tree',
 			event => unloadSubtree(gBrowser, currentTab)
 		);
 

--- a/main.js
+++ b/main.js
@@ -10,6 +10,7 @@ const { Hotkey, } = require('sdk/hotkeys');
 const baseUrl = require('sdk/self').data.url('../');
 
 const gSessionStore = Cc["@mozilla.org/browser/sessionstore;1"].getService(Ci.nsISessionStore);
+const SessionStoreNS = Cu.import('resource:///modules/sessionstore/SessionStore.jsm', {});
 Cu.importGlobalProperties([ 'btoa', ]); /* global btoa */
 const toBase64 = btoa;
 
@@ -117,7 +118,7 @@ function unloadTab(gBrowser, tab) {
 		let parent = gBrowser.treeStyleTab.getParentTab(tab);
 		if (parent) {
 			gBrowser.treeStyleTab.attachTabTo(newtab, parent,
-				{dontAnimate: true, insertBefore: tab.nextSibling});
+				{dontAnimate: true, insertBefore: gBrowser.treeStyleTab.getNextTab(tab)});
 		}
 		let children = gBrowser.treeStyleTab.getChildTabs(tab);
 		children.forEach(function(aChild) {
@@ -135,12 +136,9 @@ function unloadTab(gBrowser, tab) {
 
 /// copied from bartablitex@szabolcs.hubai
 
-	// Close the original tab.  We're taking the long way round to
-	// ensure the nsISessionStore service won't save this in the
-	// recently closed tabs.
-	if (gBrowser._beginRemoveTab(tab, true, null, false)) {
-		gBrowser._endRemoveTab(tab);
-	}
+	// Close the original tab and remove it from the recently closed tabs list
+	gBrowser.removeTab(tab);
+	SessionStoreNS.SessionStoreInternal.forgetClosedTab(gBrowser.ownerGlobal);
 
 /// end copy
 }

--- a/main.js
+++ b/main.js
@@ -151,7 +151,7 @@ function unloadTab(gBrowser, tab) {
  * @param  {<tab>}         tab       A single tab instance to exclude.
  */
 function unloadOtherTabs(gBrowser, tab) {
-	forEach(tab.parentNode.children, other => other !== tab && unloadTab(gBrowser, other));
+	forEach(gBrowser.visibleTabs, other => other !== tab && unloadTab(gBrowser, other));
 }
 
 /**


### PR DESCRIPTION
Hi,

So it seems that the problem is with the `SessionStore`. By setting the 2nd parameter of `_beginRemoveTabs`, the tab is not stored in the `SessionStore` closed tab list. But I suspect somewhere Tree Style Tabs uses this information.

So as as solution which seems to work with my limited testing, I use the normal `removeTab` method and remove the tab from the recently closed tab list by using the (_undocumented_) `forgetClosedTab` method.