### PR TITLE
Fix Tree Style Tab issues

### DIFF
--- a/background/tst.js
+++ b/background/tst.js
@@ -28,8 +28,8 @@ async function onMessageExternal(message, sender) { {
 	debug && console.log('onMessageExternal', ...arguments);
 	if (sender.id !== TST_ID) { return; }
 } try { switch (message.type) {
-	case 'ready': (await register()); break;
-	case 'fake-contextMenu-click': (await onClicked(message.info, message.tab));
+	case 'ready': (register()); return true;
+	case 'fake-contextMenu-click': (onClicked(message.info, message.tab));
 } } catch (error) { console.error('TST error', error); } }
 
 
@@ -41,7 +41,7 @@ return {
 	},
 	disable() {
 		Runtime.onMessageExternal.removeListener(onMessageExternal);
-		Runtime.sendMessage(TST_ID, { type: 'unregister-self', }).catch(() => null);
+		Runtime.sendMessage(TST_ID, { type: 'fake-contextMenu-remove-all' }).then(() => Runtime.sendMessage(TST_ID, { type: 'unregister-self', })).catch(() => null);
 	},
 };
 


### PR DESCRIPTION
This pull request address a couple of issues related to this extensions Tree Style Tab features. 
 * Close fake context menu when an item is clicked. (Don't wait for `onClicked`.)
 * Re-register when Tree Style Tab is restarted. (Return true for "ready" message) (See [Auto Tab Discard PR 49](https://github.com/rNeomy/auto-tab-discard/pull/49) for more info.)
 * Remove context menu items when unregistered. Otherwise the items causes issues for Tree Style Tab's context menu. (Send `fake-contextMenu-remove-all` message.)